### PR TITLE
#158175315 Extend the maximum timeout and grace periods

### DIFF
--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -18,8 +18,12 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    """
+    Sets the timeout and grace periods of a check with minimum value of 1 minute (60 seconds) and maximum value of 1
+    year (31536000 seconds).
+    """
+    timeout = forms.IntegerField(min_value=60, max_value=31536000)
+    grace = forms.IntegerField(min_value=60, max_value=31536000)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -4,12 +4,19 @@ $(function () {
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
     var WEEK = {name: "week", nsecs: DAY.nsecs * 7};
-    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+    var MONTH = {name: "month", nsecs: DAY.nsecs * 30};
+    var YEAR = {name: "year", nsecs: DAY.nsecs * 365};
+    var UNITS = [YEAR, MONTH, WEEK, DAY, HOUR, MINUTE];
 
     var secsToText = function(total) {
         var remainingSeconds = Math.floor(total);
+        var remainingDays = Math.floor(total);
         var result = "";
         for (var i=0, unit; unit=UNITS[i]; i++) {
+            if (unit === MONTH && remainingDays % unit.nsecs != 0) {
+                // Say "31 days" instead of "1 month 1 day"
+                continue
+            }
             if (unit === WEEK && remainingSeconds % unit.nsecs != 0) {
                 // Say "8 days" instead of "1 week 1 day"
                 continue
@@ -36,14 +43,17 @@ $(function () {
         connect: "lower",
         range: {
             'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '15%': [3600, 900],
+            '27.5%': [86400, 43200],
+            '40%': [604800, 86400],
+            '55%': [7257600, 86400],
+            '70%': [15552000, 86400],
+            '85%': [23328000, 86400],
+            'max': 31536000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 3600, 86400, 604800, 7257600, 15552000, 23328000, 31536000],
             density: 4,
             format: {
                 to: secsToText,
@@ -65,14 +75,17 @@ $(function () {
         connect: "lower",
         range: {
             'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            '15%': [3600, 900],
+            '27.5%': [86400, 43200],
+            '40%': [604800, 86400],
+            '55%': [7257600, 86400],
+            '70%': [15552000, 86400],
+            '85%': [23328000, 86400],
+            'max': 31536000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 3600, 86400, 604800, 7257600, 15552000, 23328000, 31536000],
             density: 4,
             format: {
                 to: secsToText,


### PR DESCRIPTION
#### What does this PR do?
* Extends the grace and time-out periods.
#### Description of Task to be completed?
* To extend the maximum time accepted by the `timeout` form to one year.
* Modify UI, so that a user can set these extended periods
#### How should this be manually tested?
* Clone the project from GitHub ```git clone https://github.com/andela/hc-wits-kla.git``` and set it up as indicated in the `README.md` file.
* After cloning, cd into the project directory and run the environment setup in the project README
* Run `python manage.py compress` to recompress the static files.
* Start the project `python manage.py runserver`.
*  Login and add a new check. You should be able to adjust the time-out and grace periods to upto a year as shown in the screenshot below.
#### What are the relevant pivotal tracker stories?
* [#158175315](https://www.pivotaltracker.com/story/show/158175315)
#### Screenshots 

screenshot before the changes
<img width="758" alt="screenshot before" src="https://user-images.githubusercontent.com/39955305/41977644-812d4070-7a28-11e8-921f-997d1e9681c7.png">

screenshot after the changes
<img width="878" alt="screenshot" src="https://user-images.githubusercontent.com/39955305/41972119-81c7246a-7a19-11e8-809b-5d320c47b030.png">