### PR TITLE
[Bug] Correct Nag Interval display under my checks

### DIFF
--- a/static/css/my_checks_desktop.css
+++ b/static/css/my_checks_desktop.css
@@ -127,3 +127,8 @@ tr:hover .copy-link {
     line-height: 36px;
     color: #333;
 }
+
+#checks-table .nag-interval-cell {
+    display: inline-flex;
+    align-items: center;
+}

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -75,6 +75,22 @@
                 Never
             {% endif %}
             </td>
+
+            <td class="nag-interval-cell">
+                <span
+                    data-url="{% url 'hc-nag-interval' check.code %}"
+                    data-naginterval="{{ check.nag.total_seconds }}"
+                    class="nags">
+                    {{ check.nag|hc_duration }}
+                </span>
+                <span>
+                    {% load static %}
+                    {% if check.nag_mode == "on" %}
+                        <img src="{% static 'img/nag-64.png'%}" alt="Nag" height="24" width="24" />
+                    {% endif %}
+                </span>
+            </td>
+
             <td>
                 <div class="check-menu dropdown">
                     <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">


### PR DESCRIPTION
#### What does this PR do?
Add the Missing Nag Interval for some checks

#### Description of Task to be completed?
*  When displaying my own checks, the nag interval was not working and only displayed for the team's checks

#### How should this be manually tested?
* Clone the branch, ```git clone https://github.com/andela/hc-wits-kla/tree/bg-nag-interval-display```
* In your terminal, ```cd hc-wits-kla```
* In the project directory, activate the environment, ```source hc-venv/bin/activate```
* Install requirements ```pip install requirements.txt```
* Serve the application ```python manage.py runserver```
* Serve the application ```python manage.py sendalerts``` so as to get checks that are the nag mode
* In the browser, visit, 127.0.0.1:8000/
* Login to Healthchecks and go to your checks page
* Add some checks and have them fail and go on the nag mode
* Then see if the nag interval appears as well the icon that indicates the nag mode

#### Screenshots (if appropriate)
[URL](http://127.0.0.1:8000/checks/)

<img width="1533" alt="screen shot 2018-07-17 at 16 18 56" src="https://user-images.githubusercontent.com/39955231/42819797-3d41c772-89dd-11e8-833c-d644a6a92efa.png">
